### PR TITLE
Remove incorrectly used isystem flag

### DIFF
--- a/src/R/Makefile
+++ b/src/R/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-pedantic -W -Wextra -Wall -Wno-variadic-macros -Wno-strict-aliasing -Wno-long-long -Wno-unused-parameter -fPIC -D_STDC_FORMAT_MACROS -Wno-system-headers -isystem -O2 -g -DNDEBUG -ggdb3  -D_STDC_LIMIT_MACROS -std=c99
+CFLAGS=-pedantic -W -Wextra -Wall -Wno-variadic-macros -Wno-strict-aliasing -Wno-long-long -Wno-unused-parameter -fPIC -D_STDC_FORMAT_MACROS -Wno-system-headers -O2 -g -DNDEBUG -ggdb3  -D_STDC_LIMIT_MACROS -std=c99
 INC=-I.
 
 all:


### PR DESCRIPTION
The `-isystem` flag needs to be followed by a directory, see [here](https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html). Without the patch, the flag following `-isystem` is treated as a directory and has no effect.